### PR TITLE
These changes are to solve these issues:

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
@@ -27,8 +27,8 @@
     self.textColor = [UIColor whiteColor];
     self.editable = NO;
     self.selectable = YES;
-    self.userInteractionEnabled = NO;
-    self.dataDetectorTypes = UIDataDetectorTypeNone;
+    self.userInteractionEnabled = YES;
+    self.dataDetectorTypes = UIDataDetectorTypeAll;
     self.showsHorizontalScrollIndicator = NO;
     self.showsVerticalScrollIndicator = NO;
     self.scrollEnabled = NO;
@@ -38,7 +38,7 @@
     self.contentOffset = CGPointZero;
     self.textContainerInset = UIEdgeInsetsZero;
     self.textContainer.lineFragmentPadding = 0;
-    self.linkTextAttributes = @{ NSForegroundColorAttributeName : [UIColor whiteColor],
+    self.linkTextAttributes = @{ NSForegroundColorAttributeName : [UIColor blackColor],
                                  NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle | NSUnderlinePatternSolid) };
 }
 


### PR DESCRIPTION
## What's in this pull request?

UA-1198 - [iOS] In Chatbot for some triage there is a link text in the message, When I tap on that link it is not redirecting to any browser;
UA-1201 - [iOS] Link text is not visible in the chatbot responce
