### PR TITLE
Makes it Possible to Assign the Map Pin Tint Colour.

### DIFF
--- a/JSQMessagesViewController/Categories/UIColor+JSQMessages.h
+++ b/JSQMessagesViewController/Categories/UIColor+JSQMessages.h
@@ -31,7 +31,6 @@
  *  @return A color object containing HSB values similar to the iOS 7 messages app blue bubble color.
  */
 + (UIColor *)jsq_messageBubbleBlueColor;
-+ (UIColor *)jsq_messageBubbleDarkPurpleColor;
 
 /**
  *  @return A color object containing HSB values similar to the iOS 7 red color.
@@ -42,8 +41,6 @@
  *  @return A color object containing HSB values similar to the iOS 7 messages app light gray bubble color.
  */
 + (UIColor *)jsq_messageBubbleLightGrayColor;
-
-+ (UIColor *)jsq_messageBubblePurpleColor;
 
 #pragma mark - Utilities
 

--- a/JSQMessagesViewController/Categories/UIColor+JSQMessages.m
+++ b/JSQMessagesViewController/Categories/UIColor+JSQMessages.m
@@ -24,28 +24,18 @@
 
 + (UIColor *)jsq_messageBubbleGreenColor
 {
-    return [UIColor greenColor];
+    return [UIColor colorWithHue:130.0f / 360.0f
+                      saturation:0.68f
+                      brightness:0.84f
+                           alpha:1.0f];
 }
 
 + (UIColor *)jsq_messageBubbleBlueColor
 {
-    return [UIColor purpleColor];
-}
-
-+ (UIColor *)jsq_messageBubblePurpleColor
-{
-    return [UIColor colorWithRed:144.0f/255
-                           green:19.0f/255
-                            blue:254.0f/255
+    return [UIColor colorWithHue:210.0f / 360.0f
+                      saturation:0.94f
+                      brightness:1.0f
                            alpha:1.0f];
-}
-
-+ (UIColor *)jsq_messageBubbleDarkPurpleColor
-{
-    return [UIColor colorWithRed:144.0f/255
-                           green:19.0f/255
-                            blue:254.0f/255
-                           alpha:0.5f];
 }
 
 + (UIColor *)jsq_messageBubbleRedColor

--- a/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.m
+++ b/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.m
@@ -28,8 +28,8 @@
 + (UIButton *)defaultAccessoryButtonItem
 {
     UIImage *accessoryImage = [UIImage babylon_defaultAccessoryImage];
-    UIImage *normalImage = [accessoryImage jsq_imageMaskedWithColor:[UIColor jsq_messageBubblePurpleColor]];
-    UIImage *highlightedImage = [accessoryImage jsq_imageMaskedWithColor:[UIColor jsq_messageBubbleDarkPurpleColor]];
+    UIImage *normalImage = [accessoryImage jsq_imageMaskedWithColor:[UIColor lightGrayColor]];
+    UIImage *highlightedImage = [accessoryImage jsq_imageMaskedWithColor:[UIColor darkGrayColor]];
 
     UIButton *accessoryButton = [[UIButton alloc] initWithFrame:CGRectMake(0.0f, 0.0f, accessoryImage.size.width, 32.0f)];
     [accessoryButton setImage:normalImage forState:UIControlStateNormal];
@@ -37,7 +37,7 @@
 
     accessoryButton.contentMode = UIViewContentModeScaleAspectFit;
     accessoryButton.backgroundColor = [UIColor clearColor];
-    accessoryButton.tintColor = [UIColor jsq_messageBubblePurpleColor];
+    accessoryButton.tintColor = [UIColor lightGrayColor];
     
     accessoryButton.accessibilityLabel = [NSBundle jsq_localizedStringForKey:@"accessory_button_accessibility_label"];
 
@@ -50,8 +50,8 @@
 
     UIButton *sendButton = [[UIButton alloc] initWithFrame:CGRectZero];
     [sendButton setTitle:sendTitle forState:UIControlStateNormal];
-    [sendButton setTitleColor:[UIColor jsq_messageBubblePurpleColor] forState:UIControlStateNormal];
-    [sendButton setTitleColor:[[UIColor jsq_messageBubblePurpleColor] jsq_colorByDarkeningColorWithValue:0.1f] forState:UIControlStateHighlighted];
+    [sendButton setTitleColor:[UIColor jsq_messageBubbleBlueColor] forState:UIControlStateNormal];
+    [sendButton setTitleColor:[[UIColor jsq_messageBubbleBlueColor] jsq_colorByDarkeningColorWithValue:0.1f] forState:UIControlStateHighlighted];
     [sendButton setTitleColor:[UIColor lightGrayColor] forState:UIControlStateDisabled];
 
     sendButton.titleLabel.font = [UIFont babylonMediumFont:17.0f];
@@ -59,7 +59,7 @@
     sendButton.titleLabel.minimumScaleFactor = 0.85f;
     sendButton.contentMode = UIViewContentModeCenter;
     sendButton.backgroundColor = [UIColor clearColor];
-    sendButton.tintColor = [UIColor jsq_messageBubblePurpleColor];
+    sendButton.tintColor = [UIColor jsq_messageBubbleBlueColor];
 
     CGFloat maxHeight = 32.0f;
 

--- a/JSQMessagesViewController/Layout/JSQAudioMediaViewAttributes.m
+++ b/JSQMessagesViewController/Layout/JSQAudioMediaViewAttributes.m
@@ -59,7 +59,7 @@
 
 - (instancetype)init
 {
-    UIColor *tintColor = [UIColor jsq_messageBubblePurpleColor];
+    UIColor *tintColor = [UIColor jsq_messageBubbleBlueColor];
     AVAudioSessionCategoryOptions options = AVAudioSessionCategoryOptionDuckOthers
     | AVAudioSessionCategoryOptionDefaultToSpeaker
     | AVAudioSessionCategoryOptionAllowBluetooth;

--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.h
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.h
@@ -44,8 +44,6 @@ typedef void (^JSQLocationMediaItemCompletionBlock)(void);
  *  The coordinate of the location property.
  */
 @property (readonly, nonatomic) CLLocationCoordinate2D coordinate;
-@property (strong, nonatomic) NSString *searchType;
-@property (strong, nonatomic) NSString *placeId;
 
 /**
  *  Initializes and returns a location media item object having the given location.
@@ -85,4 +83,10 @@ typedef void (^JSQLocationMediaItemCompletionBlock)(void);
  */
 - (void)setLocation:(CLLocation *)location
              region:(MKCoordinateRegion)region withCompletionHandler:(JSQLocationMediaItemCompletionBlock)completion;
+
+/**
+ * Tint color for the pin annotiation in a map view. Default is nil.
+ */
+@property (strong, nonatomic) UIColor *pinAnnotationTintColor;
+
 @end

--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -107,7 +107,6 @@
                   }
                   
                   MKPinAnnotationView *pin = [[MKPinAnnotationView alloc] initWithAnnotation:nil reuseIdentifier:nil];
-                  pin.pinTintColor = [UIColor jsq_messageBubblePurpleColor];
                   CGPoint coordinatePoint = [snapshot pointForCoordinate:location.coordinate];
                   UIImage *image = snapshot.image;
                   

--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -107,6 +107,7 @@
                   }
                   
                   MKPinAnnotationView *pin = [[MKPinAnnotationView alloc] initWithAnnotation:nil reuseIdentifier:nil];
+                  pin.pinTintColor = self.pinAnnotationTintColor;
                   CGPoint coordinatePoint = [snapshot pointForCoordinate:location.coordinate];
                   UIImage *image = snapshot.image;
                   

--- a/JSQMessagesViewController/Views/Babylon/Loading/BBMessagesTypingIndicatorFooterView.m
+++ b/JSQMessagesViewController/Views/Babylon/Loading/BBMessagesTypingIndicatorFooterView.m
@@ -48,7 +48,7 @@ const CGFloat kBBMessagesTypingIndicatorFooterViewHeight = 46.0f;
     dotParms.animationDelay = 0.2;
     dotParms.animationDuration = 0.6;
     dotParms.animationFromValue = 0.5;
-    dotParms.defaultColor = [UIColor jsq_messageBubblePurpleColor];
+    dotParms.defaultColor = [UIColor jsq_messageBubbleBlueColor];
     dotParms.isDataValidationEnabled = YES;
     return dotParms;
 }

--- a/JSQMessagesViewController/Views/Babylon/Loading/DotAnimationBuilder/BBDotActivityIndicatorParms.m
+++ b/JSQMessagesViewController/Views/Babylon/Loading/DotAnimationBuilder/BBDotActivityIndicatorParms.m
@@ -37,8 +37,7 @@
     
     self.animationToValue = (self.animationToValue == 0) ? 1.0 : self.animationToValue;
     
-    self.defaultColor = ( self.defaultColor == nil ) ? [UIColor jsq_messageBubblePurpleColor] : self.defaultColor;
-
+    self.defaultColor = ( self.defaultColor == nil ) ? [UIColor jsq_messageBubbleBlueColor] : self.defaultColor;
 }
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
@@ -89,7 +89,7 @@ forCellWithReuseIdentifier:@"incomingMixedMediaCellIdentifier"];
     _typingIndicatorMessageBubbleColor = [UIColor jsq_messageBubbleLightGrayColor];
     _typingIndicatorEllipsisColor = [_typingIndicatorMessageBubbleColor jsq_colorByDarkeningColorWithValue:0.3f];
 
-    _loadEarlierMessagesHeaderTextColor = [UIColor jsq_messageBubblePurpleColor];
+    _loadEarlierMessagesHeaderTextColor = [UIColor jsq_messageBubbleBlueColor];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -51,7 +51,6 @@
     self.font = [UIFont systemFontOfSize:16.0f];
     self.textColor = [UIColor blackColor];
     self.textAlignment = NSTextAlignmentNatural;
-    self.tintColor = [UIColor jsq_messageBubblePurpleColor];
 
     self.contentMode = UIViewContentModeRedraw;
     self.dataDetectorTypes = UIDataDetectorTypeNone;


### PR DESCRIPTION

Since it must be possible to assign a brand colour in all places where the legacy code used a hard-coded babylon purple colour, I decided to delete the hard-coded babylon colours. Definitions for the blue and green colours have been reset to the values in master.


