### PR TITLE
Fix issue with iOS 11 UITextView having the same property name

### DIFF
--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -41,7 +41,7 @@
     
     self.title = @"JSQMessages";
 
-    self.inputToolbar.contentView.textView.pasteDelegate = self;
+    self.inputToolbar.contentView.textView.jsq_pasteDelegate = self;
     
     /**
      *  Load up our fake data for the demo

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  The object that acts as the paste delegate of the text view.
  */
-@property (weak, nonatomic, nullable) id<JSQMessagesComposerTextViewPasteDelegate> pasteDelegate;
+@property (weak, nonatomic, nullable) id<JSQMessagesComposerTextViewPasteDelegate> jsq_pasteDelegate;
 
 /**
  *  Determines whether or not the text view contains text after trimming white space 

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -218,7 +218,7 @@
 
 - (void)paste:(id)sender
 {
-    if (!self.pasteDelegate || [self.pasteDelegate composerTextView:self shouldPasteWithSender:sender]) {
+    if (!self.jsq_pasteDelegate || [self.jsq_pasteDelegate composerTextView:self shouldPasteWithSender:sender]) {
         [super paste:sender];
     }
 }


### PR DESCRIPTION
#### Issue
There is an issue with iOS11 `UITextView` having [property](https://developer.apple.com/documentation/uikit/uitextpasteconfigurationsupporting#topics) with the same name

#### Solution

Rename it to `jsq_pasteDelegate`