### PR TITLE
Fix issue with insets on iOS 11

### DIFF
--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -36,14 +36,12 @@
     [super viewDidLoad];
     
     self.title = @"JSQMessages";
-    
     /**
      *  You MUST set your senderId and display name
      */
     self.senderId = kJSQDemoAvatarIdSquires;
     self.senderDisplayName = kJSQDemoAvatarDisplayNameSquires;
-    
-    self.inputToolbar.contentView.textView.pasteDelegate = self;
+    self.inputToolbar.contentView.textView.jsq_pasteDelegate = self;
     
     /**
      *  Load up our fake data for the demo

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -207,6 +207,9 @@ JSQMessagesKeyboardControllerDelegate>
     self.topContentAdditionalInset = 0.0f;
 
     [self jsq_updateCollectionViewInsets];
+    if (@available(iOS 11.0, *)) {
+        self.collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    }
 
     // Don't set keyboardController if client creates custom content view via -loadToolbarContentView
     if (self.inputToolbar.contentView.textView != nil) {

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
@@ -55,7 +55,7 @@
 /**
  *  The object that acts as the paste delegate of the text view.
  */
-@property (weak, nonatomic) id<JSQMessagesComposerTextViewPasteDelegate> pasteDelegate;
+@property (weak, nonatomic, nullable) id<JSQMessagesComposerTextViewPasteDelegate> jsq_pasteDelegate;
 
 /**
  *  Determines whether or not the text view contains text after trimming white space 

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -143,7 +143,7 @@
 
 - (void)paste:(id)sender
 {
-    if (!self.pasteDelegate || [self.pasteDelegate composerTextView:self shouldPasteWithSender:sender]) {
+    if (!self.jsq_pasteDelegate || [self.jsq_pasteDelegate composerTextView:self shouldPasteWithSender:sender]) {
         [super paste:sender];
     }
 }


### PR DESCRIPTION
### Screen shots

iOS version | Before | After 
--- | ---  | ---
iOS 10 | ![ios10-before](https://user-images.githubusercontent.com/4622322/31453724-04d1d048-aeab-11e7-8afb-52d32415b01b.gif) | ![ios10-after](https://user-images.githubusercontent.com/4622322/31453744-0e0e8ed0-aeab-11e7-9fc4-3c183131dfbd.gif)
iOS 11 | ![ios11-before](https://user-images.githubusercontent.com/4622322/31453756-1775e090-aeab-11e7-93cf-783fff2d4779.gif) | ![ios11-after](https://user-images.githubusercontent.com/4622322/31453774-2084d9f2-aeab-11e7-83cf-e4b94397fb38.gif)

