### PR TITLE
Fix RAC swizzling related crash

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -26,6 +26,7 @@
 #import "UIView+JSQMessages.h"
 #import "UIDevice+JSQMessages.h"
 #import "UIFont+JSQMessages.h"
+#import <objc/message.h>
 
 static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 
@@ -103,6 +104,7 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 + (void)registerMenuAction:(SEL)action
 {
     [jsqMessagesCollectionViewCellActions addObject:NSStringFromSelector(action)];
+    class_replaceMethod([JSQMessagesCollectionViewCell class], action, _objc_msgForward, "v@:@");
 }
 
 #pragma mark - Initialization


### PR DESCRIPTION
The issue is that when we use RAC `reactive.prepareForResue` it creates a subclass in the runtime to forward method calls events. It does not work with `registerMenuAction` where they do not register actual selector but "track" that they are which then messes up with message forwarding in RAC buy crashing.

This change just redirects all `MenuAction` selectors to the msg forwarding